### PR TITLE
fix(dataset): 修复删除知识库功能

### DIFF
--- a/src/main/java/io/github/yuanbaobaoo/dify/dataset/heros/DatasetHero.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/dataset/heros/DatasetHero.java
@@ -103,7 +103,9 @@ public class DatasetHero extends Dataset {
      * 删除数据库
      */
     public void delete() {
-        DifyHttpClient.get(config).requestJson(DatasetRoutes.DATASETS_DELETE);
+        DifyHttpClient.get(config).requestJson(DatasetRoutes.DATASETS_DELETE.format(new HashMap<>() {{
+            put("datasetId", getId());
+        }}));
     }
 
     /**

--- a/src/main/java/io/github/yuanbaobaoo/dify/routes/DatasetRoutes.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/routes/DatasetRoutes.java
@@ -9,7 +9,7 @@ public class DatasetRoutes {
      * Type: Dataset
      */
     public static final DifyRoute DATASETS = new DifyRoute("/datasets", HttpMethod.POST);
-    public static final DifyRoute DATASETS_DELETE = new DifyRoute(DATASETS.getUrl(), HttpMethod.DELETE);
+    public static final DifyRoute DATASETS_DELETE = new DifyRoute("/datasets/${datasetId}", HttpMethod.DELETE);
 
     public static final DifyRoute DATASETS_RETRIEVE = new DifyRoute(
             "/datasets/${datasetId}/retrieve",


### PR DESCRIPTION
- 在 DatasetHero 类的 delete 方法中添加了 datasetId 参数
- 更新了 DatasetRoutes 类中的 DATASETS_DELETE 路由，使用参数化路径