### PR TITLE
feat(web): 增加 refresh token 功能

### DIFF
--- a/src/main/java/io/github/yuanbaobaoo/dify/types/ApiConfig.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/types/ApiConfig.java
@@ -17,4 +17,9 @@ public class ApiConfig {
      * Api Key
      */
     private String apiKey;
+
+    /**
+     * refreshToken
+     */
+    private String refreshToken;
 }

--- a/src/main/java/io/github/yuanbaobaoo/dify/utils/WebClientBuilder.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/utils/WebClientBuilder.java
@@ -5,6 +5,7 @@ import io.github.yuanbaobaoo.dify.types.DifyException;
 import io.github.yuanbaobaoo.dify.types.WebConfig;
 import io.github.yuanbaobaoo.dify.web.WebAuthService;
 import io.github.yuanbaobaoo.dify.web.IWebConsoleClient;
+import io.github.yuanbaobaoo.dify.web.entity.TokenList;
 import io.github.yuanbaobaoo.dify.web.impl.WebClientImpl;
 
 /**
@@ -89,8 +90,8 @@ public class WebClientBuilder {
 
         try {
             WebConfig config = WebConfig.builder().server(server).userName(userName).password(password).build();
-            String token = WebAuthService.login(config);
-            return new WebClientImpl(server, token);
+            TokenList tokenList = WebAuthService.login(config);
+            return new WebClientImpl(server, tokenList);
         } catch (DifyClientException | DifyException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/io/github/yuanbaobaoo/dify/web/IWebConsoleClient.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/web/IWebConsoleClient.java
@@ -3,6 +3,7 @@ package io.github.yuanbaobaoo.dify.web;
 import com.alibaba.fastjson2.JSONObject;
 import io.github.yuanbaobaoo.dify.SimpleHttpClient;
 import io.github.yuanbaobaoo.dify.types.DifyPage;
+import io.github.yuanbaobaoo.dify.web.entity.TokenList;
 
 public interface IWebConsoleClient {
     /**
@@ -14,7 +15,10 @@ public interface IWebConsoleClient {
      * 获取登录的Access token
      */
     String token();
-
+    /**
+     * 获取登录的Refresh token
+     */
+    String refreshToken();
     /**
      * 查询应用列表
      * @param page int

--- a/src/main/java/io/github/yuanbaobaoo/dify/web/WebAuthService.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/web/WebAuthService.java
@@ -7,6 +7,7 @@ import io.github.yuanbaobaoo.dify.routes.ConsoleRoutes;
 import io.github.yuanbaobaoo.dify.types.DifyClientException;
 import io.github.yuanbaobaoo.dify.SimpleHttpClient;
 import io.github.yuanbaobaoo.dify.types.WebConfig;
+import io.github.yuanbaobaoo.dify.web.entity.TokenList;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -22,19 +23,11 @@ public class WebAuthService {
         private String result;
     }
 
-    @Getter
-    @Setter
-    @JSONType(naming = PropertyNamingStrategy.SnakeCase)
-    private static class TokenList {
-        private String accessToken;
-        private String refreshToken;
-    }
-
     /**
      * 登录
      * @param config DifyWebConfig
      */
-    public static String login(WebConfig config) {
+    public static TokenList login(WebConfig config) {
         SimpleHttpClient client = SimpleHttpClient.newHttpClient(config.getServer());
 
         String result = client.requestJson(ConsoleRoutes.LOGIN, null, new HashMap<>() {{
@@ -47,7 +40,7 @@ public class WebAuthService {
         LoginResult loginResult = JSON.parseObject(result, LoginResult.class);
 
         if ("success".equals(loginResult.getResult())) {
-            return loginResult.getData().getAccessToken();
+            return loginResult.getData();
         }
 
         throw new DifyClientException("登录失败: " + result);

--- a/src/main/java/io/github/yuanbaobaoo/dify/web/entity/TokenList.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/web/entity/TokenList.java
@@ -1,0 +1,14 @@
+package io.github.yuanbaobaoo.dify.web.entity;
+
+import com.alibaba.fastjson2.PropertyNamingStrategy;
+import com.alibaba.fastjson2.annotation.JSONType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JSONType(naming = PropertyNamingStrategy.SnakeCase)
+public class TokenList {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/io/github/yuanbaobaoo/dify/web/impl/WebClientImpl.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/web/impl/WebClientImpl.java
@@ -9,6 +9,7 @@ import io.github.yuanbaobaoo.dify.types.ApiConfig;
 import io.github.yuanbaobaoo.dify.SimpleHttpClient;
 import io.github.yuanbaobaoo.dify.types.DifyRoute;
 import io.github.yuanbaobaoo.dify.web.IWebConsoleClient;
+import io.github.yuanbaobaoo.dify.web.entity.TokenList;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -20,11 +21,12 @@ public class WebClientImpl implements IWebConsoleClient {
 
     /**
      * constructor
+     *
      * @param server Dify 服务地址
-     * @param token Dify access token
+     * @param token  Dify access token
      */
-    public WebClientImpl(String server, String token) {
-        config = ApiConfig.builder().server(server).apiKey(token).build();
+    public WebClientImpl(String server, TokenList token) {
+        config = ApiConfig.builder().server(server).apiKey(token.getAccessToken()).refreshToken(token.getRefreshToken()).build();
     }
 
     @Override
@@ -38,6 +40,11 @@ public class WebClientImpl implements IWebConsoleClient {
     }
 
     @Override
+    public String refreshToken() {
+        return config.getRefreshToken();
+    }
+
+    @Override
     public DifyPage<JSONObject> queryApps(int page, int limit, String name) {
         String result = SimpleHttpClient.get(config).requestJson(ConsoleRoutes.APPS, new HashMap<>() {{
             put("page", page);
@@ -45,7 +52,8 @@ public class WebClientImpl implements IWebConsoleClient {
             put("name", name);
         }});
 
-        return JSON.parseObject(result, new TypeReference<DifyPage<JSONObject>>() {});
+        return JSON.parseObject(result, new TypeReference<DifyPage<JSONObject>>() {
+        });
     }
 
 }


### PR DESCRIPTION
- 在 ApiConfig 中添加 refreshToken 字段
- 在 IWebConsoleClient 接口中添加 refreshToken 方法
- 新增 TokenList 类用于存储 access token 和 refresh token
- 修改 WebAuthService.login 方法返回 TokenList 对象
- 更新 WebClientBuilder 和 WebClientImpl 以支持 refresh token