### PR TITLE
Fixbug: 升级Dify版本后，m4a格式音频转文字 异常

### DIFF
--- a/src/main/java/io/github/yuanbaobaoo/dify/app/IAppBaseClient.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/app/IAppBaseClient.java
@@ -71,6 +71,16 @@ public interface IAppBaseClient {
     String audioToText(File file, String user);
 
     /**
+     * 语音转文字
+     *
+     * @param file 语音文件。 支持格式：['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm'] 文件
+     *             大小限制：15MB
+     * @param user 用户标识，由开发者定义规则，需保证用户标识在应用内唯一。
+     * @param fileType 如果该参数不为空，那么file对象的ContentType将设置为该值。
+     */
+    String audioToText(File file, String user, String fileType);
+
+    /**
      * 文字转语音
      *
      * @param user      用户标识，由开发者定义规则，需保证用户标识在应用内唯一

--- a/src/main/java/io/github/yuanbaobaoo/dify/app/impl/AppBaseClientImpl.java
+++ b/src/main/java/io/github/yuanbaobaoo/dify/app/impl/AppBaseClientImpl.java
@@ -82,12 +82,17 @@ public class AppBaseClientImpl implements IAppBaseClient {
 
     @Override
     public String audioToText(File file, String user) {
+        return audioToText(file, user, null);
+    }
+
+    @Override
+    public String audioToText(File file, String user, String fileType) {
         Map<String, Object> data = new HashMap<>();
         data.put("file", file);
         data.put("user", user);
 
         JSONObject result = JSON.parseObject(
-                SimpleHttpClient.get(config).requestMultipart(AppRoutes.AUDIO_TO_TEXT, null, data)
+                SimpleHttpClient.get(config).requestMultipart(AppRoutes.AUDIO_TO_TEXT, null, data, fileType)
         );
 
         return result.getString("text");


### PR DESCRIPTION
## Fixbugs
- #33 

## Changes
- 新增接口
```code
/**
 * 语音转文字
 *
 * @param file 语音文件。 支持格式：['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm'] 文件
 *             大小限制：15MB
 * @param user 用户标识，由开发者定义规则，需保证用户标识在应用内唯一。
 * @param fileType 如果该参数不为空，那么file对象的ContentType将设置为该值。
 */
String audioToText(File file, String user, String fileType);
```